### PR TITLE
Fixed insecure URL

### DIFF
--- a/docs/intro/cvmfs.md
+++ b/docs/intro/cvmfs.md
@@ -5,4 +5,4 @@
 SWAN uses CVMFS to access collections of software, called LCG releases. An LCG Release is a set of several (~200) software packages consistently built together. When a user logs into SWAN, they can select a particular LCG release and their software environment is configured accordingly.
 
 If you want to know what packages, and corresponding versions, are available in each release, please check the 
-[LCG info page](http://lcginfo.cern.ch/).
+[LCG info page](https://lcginfo.cern.ch/).


### PR DESCRIPTION
The link to a plain HTTP URL is marked as 'insecure' on modern browsers.