### PR TITLE
Change link to the hadoop introduction one

### DIFF
--- a/docs/spark/clusters.md
+++ b/docs/spark/clusters.md
@@ -1,6 +1,6 @@
 # Running Spark on CERN Clusters
 
-SWAN also allows to submit computations to Spark Clusters located at CERN. If you are interested in accessing these clusters, please follow the procedure indicated in the [Hadoop User Guide](https://hadoop-user-guide.web.cern.ch/getstart/access.html), as you need to be added to a specific e-group.
+SWAN also allows to submit computations to Spark Clusters located at CERN. If you are interested in accessing these clusters, please follow the procedure indicated in the [Hadoop User Guide](https://hadoop-user-guide.web.cern.ch/getstart/access/), as you need to be added to a specific e-group.
 
 ### Selection of a Spark Cluster
 


### PR DESCRIPTION
The current link does not work and redirects to a 404 Not Found page. I changed the link to a working one, which directs the user to the Hadoop introduction page.