### PR TITLE
Remove docs regarding default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
     * [Software: CVMFS](docs/intro/cvmfs.md)
 * Create and manage a SWAN session
     * [Select a configuration](docs/session/select.md)
-    * [Set a configuration as default](docs/session/set_default.md)
     * [Switch to a new configuration](docs/session/switch.md)
     * [Terminate a session](docs/session/terminate.md)
 * Working with SWAN

--- a/docs/session/set_default.md
+++ b/docs/session/set_default.md
@@ -1,3 +1,0 @@
-# Set a configuration as default
-
-If there is a configuration that you normally use, you do not have to select it every time you start a session. Instead, you can tick the **`Always start with this configuration`** check box that is located at the bottom of the configuration form. This way, the next time you start a session SWAN will automatically load your preferred configuration.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,6 @@ nav:
     - intro/cvmfs.md
   - Create and manage a SWAN session:
     - session/select.md
-    - session/set_default.md
     - session/switch.md
     - session/terminate.md
   - Working with SWAN:


### PR DESCRIPTION
This part of the documentation was removed, as the option is no longer available in the session startup form